### PR TITLE
fix: Use PUBG_API_KEYS (plural) in match_discovery

### DIFF
--- a/src/pewstats_collectors/services/match_discovery.py
+++ b/src/pewstats_collectors/services/match_discovery.py
@@ -323,7 +323,7 @@ def discover_matches(max_players: int, env_file: str, log_level: str):
             "POSTGRES_DB",
             "POSTGRES_USER",
             "POSTGRES_PASSWORD",
-            "PUBG_API_KEY",
+            "PUBG_API_KEYS",
             "RABBITMQ_HOST",
             "RABBITMQ_USER",
             "RABBITMQ_PASSWORD",
@@ -344,7 +344,11 @@ def discover_matches(max_players: int, env_file: str, log_level: str):
             password=os.getenv("POSTGRES_PASSWORD"),
         ) as db:
             # Initialize API key manager
-            api_keys = [{"key": os.getenv("PUBG_API_KEY"), "rpm": 10}]
+            # Parse comma-separated API keys
+            api_keys_str = os.getenv("PUBG_API_KEYS", "")
+            api_keys = [{"key": key.strip(), "rpm": 10} for key in api_keys_str.split(",") if key.strip()]
+            if not api_keys:
+                raise ValueError("PUBG_API_KEYS is set but contains no valid keys")
             api_key_manager = APIKeyManager(api_keys)
 
             # Initialize PUBG client


### PR DESCRIPTION
## Fix
Change match_discovery service to use `PUBG_API_KEYS` (plural) instead of `PUBG_API_KEY` (singular)

## Problem
The service was looking for `PUBG_API_KEY` but the environment variable is named `PUBG_API_KEYS` (plural), causing deployment failures.

## Solution
- Updated required environment variable from `PUBG_API_KEY` to `PUBG_API_KEYS`
- Parse comma-separated API keys from the environment variable
- Create list of key objects for APIKeyManager

## Testing
- ✅ Code updated and tested
- ✅ Consistent with `.env.example` configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)