### PR TITLE
fix: Use PUBG_API_KEYS and format code

### DIFF
--- a/src/pewstats_collectors/services/match_discovery.py
+++ b/src/pewstats_collectors/services/match_discovery.py
@@ -346,7 +346,9 @@ def discover_matches(max_players: int, env_file: str, log_level: str):
             # Initialize API key manager
             # Parse comma-separated API keys
             api_keys_str = os.getenv("PUBG_API_KEYS", "")
-            api_keys = [{"key": key.strip(), "rpm": 10} for key in api_keys_str.split(",") if key.strip()]
+            api_keys = [
+                {"key": key.strip(), "rpm": 10} for key in api_keys_str.split(",") if key.strip()
+            ]
             if not api_keys:
                 raise ValueError("PUBG_API_KEYS is set but contains no valid keys")
             api_key_manager = APIKeyManager(api_keys)


### PR DESCRIPTION
- Change from PUBG_API_KEY (singular) to PUBG_API_KEYS (plural)
- Parse comma-separated API keys and create key list
- Format code with ruff

🤖 Generated with [Claude Code](https://claude.com/claude-code)