### PR TITLE
fix: Add __main__ blocks to workers and continuous loop to match_disc…

### DIFF
--- a/src/pewstats_collectors/services/match_discovery.py
+++ b/src/pewstats_collectors/services/match_discovery.py
@@ -393,4 +393,17 @@ def discover_matches(max_players: int, env_file: str, log_level: str):
 
 
 if __name__ == "__main__":
-    discover_matches()
+    import time
+
+    # Run continuously with 10 minute interval
+    interval = int(os.getenv("DISCOVERY_INTERVAL", "600"))  # Default 10 minutes
+    logger.info(f"Starting match discovery service (interval: {interval}s)")
+
+    while True:
+        try:
+            discover_matches()
+        except Exception as e:
+            logger.error(f"Match discovery run failed: {e}")
+
+        logger.info(f"Sleeping for {interval} seconds...")
+        time.sleep(interval)

--- a/src/pewstats_collectors/workers/telemetry_download_worker.py
+++ b/src/pewstats_collectors/workers/telemetry_download_worker.py
@@ -364,3 +364,47 @@ def is_gzipped(file_path: str) -> bool:
         return magic == b"\x1f\x8b"
     except (IOError, OSError):
         return False
+
+
+if __name__ == "__main__":
+    import os
+    from pewstats_collectors.core.database_manager import DatabaseManager
+    from pewstats_collectors.core.rabbitmq_consumer import RabbitMQConsumer
+
+    # Configure logging
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO"),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    # Initialize database manager
+    db_manager = DatabaseManager(
+        host=os.getenv("POSTGRES_HOST"),
+        port=int(os.getenv("POSTGRES_PORT", "5432")),
+        dbname=os.getenv("POSTGRES_DB"),
+        user=os.getenv("POSTGRES_USER"),
+        password=os.getenv("POSTGRES_PASSWORD"),
+    )
+
+    # Initialize worker
+    worker = TelemetryDownloadWorker(
+        database_manager=db_manager,
+        storage_path=os.getenv("TELEMETRY_STORAGE_PATH", "/opt/pewstats-platform/data/telemetry"),
+        worker_id=os.getenv("WORKER_ID", "telemetry-download-worker-1"),
+    )
+
+    # Initialize consumer
+    consumer = RabbitMQConsumer(
+        host=os.getenv("RABBITMQ_HOST"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        user=os.getenv("RABBITMQ_USER", "guest"),
+        password=os.getenv("RABBITMQ_PASSWORD", "guest"),
+        vhost=os.getenv("RABBITMQ_VHOST", "/"),
+        queue_name="telemetry_downloads",
+        callback=worker.process_message,
+        environment=os.getenv("ENVIRONMENT", "development"),
+    )
+
+    # Start consuming
+    print(f"Starting telemetry download worker: {worker.worker_id}")
+    consumer.start_consuming()


### PR DESCRIPTION
…overy

- Workers now start consuming from RabbitMQ queues continuously
- Match discovery runs in a loop with configurable interval (default 10 min)
- Fixes RuntimeWarning about modules in sys.modules
- Workers will now stay alive and process messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)