### PR TITLE
fix: Re-apply RabbitMQ parameter fixes after merge

### DIFF
--- a/src/pewstats_collectors/workers/match_summary_worker.py
+++ b/src/pewstats_collectors/workers/match_summary_worker.py
@@ -622,7 +622,7 @@ if __name__ == "__main__":
     consumer = RabbitMQConsumer(
         host=os.getenv("RABBITMQ_HOST"),
         port=int(os.getenv("RABBITMQ_PORT", "5672")),
-        user=os.getenv("RABBITMQ_USER", "guest"),
+        username=os.getenv("RABBITMQ_USER", "guest"),
         password=os.getenv("RABBITMQ_PASSWORD", "guest"),
         vhost=os.getenv("RABBITMQ_VHOST", "/"),
         queue_name="match_summaries",


### PR DESCRIPTION
Changed user= to username= in RabbitMQConsumer calls. The previous fixes were lost during the main->develop merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)