### PR TITLE
fix: Worker crashes and API rate limiting

### DIFF
--- a/src/pewstats_collectors/workers/match_summary_worker.py
+++ b/src/pewstats_collectors/workers/match_summary_worker.py
@@ -625,11 +625,9 @@ if __name__ == "__main__":
         username=os.getenv("RABBITMQ_USER", "guest"),
         password=os.getenv("RABBITMQ_PASSWORD", "guest"),
         vhost=os.getenv("RABBITMQ_VHOST", "/"),
-        queue_name="match_summaries",
-        callback=worker.process_message,
         environment=os.getenv("ENVIRONMENT", "production"),
     )
 
     # Start consuming
     print(f"Starting match summary worker: {worker.worker_id}")
-    consumer.start_consuming()
+    consumer.consume_messages("match", "summaries", worker.process_message)

--- a/src/pewstats_collectors/workers/telemetry_download_worker.py
+++ b/src/pewstats_collectors/workers/telemetry_download_worker.py
@@ -400,11 +400,9 @@ if __name__ == "__main__":
         username=os.getenv("RABBITMQ_USER", "guest"),
         password=os.getenv("RABBITMQ_PASSWORD", "guest"),
         vhost=os.getenv("RABBITMQ_VHOST", "/"),
-        queue_name="telemetry_downloads",
-        callback=worker.process_message,
         environment=os.getenv("ENVIRONMENT", "development"),
     )
 
     # Start consuming
     print(f"Starting telemetry download worker: {worker.worker_id}")
-    consumer.start_consuming()
+    consumer.consume_messages("match", "telemetry_downloads", worker.process_message)

--- a/src/pewstats_collectors/workers/telemetry_processing_worker.py
+++ b/src/pewstats_collectors/workers/telemetry_processing_worker.py
@@ -366,11 +366,9 @@ if __name__ == "__main__":
         username=os.getenv("RABBITMQ_USER", "guest"),
         password=os.getenv("RABBITMQ_PASSWORD", "guest"),
         vhost=os.getenv("RABBITMQ_VHOST", "/"),
-        queue_name="telemetry_processing",
-        callback=worker.process_message,
         environment=os.getenv("ENVIRONMENT", "development"),
     )
 
     # Start consuming
     print(f"Starting telemetry processing worker: {worker.worker_id}")
-    consumer.start_consuming()
+    consumer.consume_messages("match", "telemetry_processing", worker.process_message)


### PR DESCRIPTION
## Fixes

### Worker Crashes
- Fixed `RabbitMQConsumer` parameter mismatch (`user=` → `username=`)
- Fixed `RabbitMQConsumer` usage (removed `queue_name`, `callback` from init, use `consume_messages()`)

### API Rate Limiting
- Implemented proactive pacing to avoid hitting rate limits
- Changed `select_key()` to skip limited keys and only wait when ALL keys are at limit
- Prevents spamming 10 requests immediately then waiting 53s

## Testing
- All unit tests pass
- Linting and formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)