### PR TITLE
fix: remove unused storage_path parameter from telemetry processing w…

### DIFF
--- a/src/pewstats_collectors/workers/telemetry_processing_worker.py
+++ b/src/pewstats_collectors/workers/telemetry_processing_worker.py
@@ -355,7 +355,6 @@ if __name__ == "__main__":
     # Initialize worker
     worker = TelemetryProcessingWorker(
         database_manager=db_manager,
-        storage_path=os.getenv("TELEMETRY_STORAGE_PATH", "/opt/pewstats-platform/data/telemetry"),
         worker_id=os.getenv("WORKER_ID", "telemetry-processing-worker-1"),
     )
 


### PR DESCRIPTION
…orker

The TelemetryProcessingWorker.__init__() doesn't accept a storage_path parameter, but the main block was trying to pass it, causing a TypeError.

Removed the unused parameter from worker initialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)